### PR TITLE
use docker/metadata-action, support multiple tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,6 @@ inputs:
   tag:
     description: "Custom docker tag"
     required: false
-  tag_latest:
-    description: "Create latest docker tag"
-    required: false
-    default: "false"
   project_id:
     description: "Google Cloud project ID"
     required: true
@@ -58,9 +54,8 @@ runs:
         images: |
           ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}
         tags: |
-          type=raw,enable=${{ inputs.tag != '' }},value=${{ inputs.tag }},priority=9002
-          type=sha,prefix={{date 'YYYY-MM-DD'}}-,priority=9001
-          type=raw,enable=${{ inputs.tag_latest == 'true' }},value=latest,priority=9000
+          type=sha,prefix={{date 'YYYY-MM-DD'}}-,priority=9002
+          type=raw,enable=${{ inputs.tag != '' }},value=${{ inputs.tag }},priority=9001
     - name: Build and push
       uses: docker/build-push-action@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   tag:
     description: "Custom docker tag"
     required: false
+  tag_latest:
+    description: "Create latest docker tag"
+    required: false
+    default: "false"
   project_id:
     description: "Google Cloud project ID"
     required: true
@@ -28,10 +32,10 @@ inputs:
 outputs:
   tag:
     description: "Release tag"
-    value: ${{ steps.setup.outputs.NEW_VERSION }}
+    value: ${{ steps.set-outputs.outputs.NEW_VERSION }}
   image:
     description: "Image name"
-    value: ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}:${{ steps.setup.outputs.NEW_VERSION }}
+    value: ${{ steps.set-outputs.outputs.IMAGE }}
 runs:
   using: "composite"
   steps:
@@ -46,21 +50,32 @@ runs:
       shell: bash
       id: "setup"
       run: |
-        if [ -z "${{ inputs.tag }}" ]; then
-          echo "NEW_VERSION=$(date '+%Y.%-m.%-d')-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        else
-          echo "NEW_VERSION=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-        fi
         echo "REPO_NAME=${GITHUB_REPOSITORY/$GITHUB_REPOSITORY_OWNER\//}" >> $GITHUB_OUTPUT
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}
+        tags: |
+          type=raw,enable=${{ inputs.tag != '' }},value=${{ inputs.tag }},priority=9002
+          type=sha,prefix={{date 'YYYY-MM-DD'}}-,priority=9001
+          type=raw,enable=${{ inputs.tag_latest == 'true' }},value=latest,priority=9000
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       with:
         context: ${{ inputs.docker_context }}
         file: ${{ inputs.dockerfile }}
         push: ${{ inputs.push_image }}
-        tags: ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}:${{ steps.setup.outputs.NEW_VERSION }}
-        labels: |
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.version=${{ steps.setup.outputs.NEW_VERSION }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+    # For some reason, nested composite outputs aren't properly evaluated, so we need to set them again. 
+    - name: Set outputs
+      shell: bash
+      id: set-outputs
+      run: |
+        echo "NEW_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_OUTPUT
+        echo "IMAGE=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
+


### PR DESCRIPTION
Autogenerated sha tag is always output with the highest priority, which is what we'll output to the image variable. Custom tags are just additional tags to be pushed to the container registry, if set.