### PR TITLE
propagate context input to file argument in docker-build-push

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: docker/build-push-action@v4
       with:
         context: ${{ inputs.docker_context }}
-        file: ${{ inputs.dockerfile }}
+        file: ${{ inputs.docker_context }}/${{ inputs.dockerfile }}
         push: ${{ inputs.push_image }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Vi får en feil som ser ut til å være på grunn av at file ikke tar hensyn til context: 
`Error: buildx failed with: ERROR: failed to solve: failed to read dockerfile: open /tmp/buildkit-mount705801618/Dockerfile: no such file or directory`

ref: https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/actions/runs/4424166622/jobs/7757664615