### PR TITLE
allow configuration of docker metadata context

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
           build_secrets:
             | # optional, default empty. See https://docs.docker.com/build/ci/github-actions/secrets/
             key=string
+          metadata_context: workflow # optional, default workflow (must be one of "git" or "workflow"). See https://github.com/docker/metadata-action#context-input
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }} # required, but is defined as an organization variable
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} # required, but is defined as an organization secret
       - name: Deploy

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
   build_secrets:
     description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)"
     required: false
+  metadata_context:
+    description: "Metadata context; see https://github.com/docker/metadata-action#context-input"
+    default: "workflow"
 outputs:
   tag:
     description: "Release tag"
@@ -82,6 +85,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v4
       with:
+        context: ${{ inputs.metadata_context }}
         images: |
           ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}
         tags: |


### PR DESCRIPTION
See https://nav-it.slack.com/archives/C5KUST8N6/p1683561444028229

It's kind of wonky though with regards to detached heads and metadata-action's implementation for resolving the ref (`git symbolic-ref HEAD`), so maybe we should solve this some other way. Thoughts?