### PR TITLE
Add support for platforms pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} # required, but is defined as an organization secret
           salsa: true # optional, default true, generates a attestation for the image
           byosbom: # defaults to use Trivy for SBOM generation, if salsa is true, but can be overwritten sending in a path to a  pre-generated SBOM
+          platforms: # optional, pass trough to docker/build-push-action. See https://github.com/docker/build-push-action#usage. Requires setup-qemu-action, https://github.com/docker/setup-qemu-action#usage
       - name: Deploy
         uses: nais/deploy/actions/deploy@v1
         env:

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
         cache-to: ${{ inputs.cache_to }}
         build-args: ${{ inputs.build_args }}
         secrets: ${{ inputs.build_secrets }}
-        platforms: $(( inputs.platforms }}
+        platforms: ${{ inputs.platforms }}
     - name: Check for errors
       if: ${{ failure() && steps.build_push.outcome == 'failure' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,9 @@ inputs:
     description: "Bring your own, use existing SBOM for SLSA"
     required: false
     default: "auto-generate-for-me-please.json"
+  platforms:
+    description: "List of target platforms for build"
+    required: false
 outputs:
   salsa:
     description: "SLSA attestation"
@@ -114,6 +117,7 @@ runs:
         cache-to: ${{ inputs.cache_to }}
         build-args: ${{ inputs.build_args }}
         secrets: ${{ inputs.build_secrets }}
+        platforms: $(( inputs.platforms }}
     - name: Check for errors
       if: ${{ failure() && steps.build_push.outcome == 'failure' }}
       shell: bash


### PR DESCRIPTION
This should enable us to build images targeting different platforms (like modern macs).

Useful for running images locally while developing.

Co-authored-by: Per-Christian Nielsen <per-christian.nielsen@nav.no>
Co-authored-by: Ingrid Fosså <ingrid.fossa@nav.no>