### PR TITLE
feat(action): add support for additional CycloneDX SBOM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ jobs:
           target: runtime # optional, default empty
           salsa: true # optional, default true, generates a attestation for the image
           byosbom: # defaults to use Trivy for SBOM generation, if salsa is true, but can be overwritten sending in a path to a  pre-generated SBOM
+          additional_sboms: | # optional, newline-separated list of extra CycloneDX SBOM files to merge with the primary SBOM
+            npm-sbom.json
+            frontend-sbom.json
           platforms: # optional, pass trough to docker/build-push-action. See https://github.com/docker/build-push-action#usage. Requires setup-qemu-action, https://github.com/docker/setup-qemu-action#usage
       - name: Deploy
         uses: nais/deploy/actions/deploy@v2
@@ -55,6 +58,8 @@ This action depends on [nais/login](https://github.com/nais/login) to authentica
 ## SLSA
 
 This action [signs](https://doc.nais.io/security/salsa/salsa/?h=slsa#what-is-slsa) the image so that its integrity can be verified by anyone wanting to use it. A "Software Bill Of Materials" is also automatically generated unless you bring your own. This happens "keylessly" behind the scenes, and the signatures are uploaded to the public [transparency log](https://search.sigstore.dev/).
+
+If you need to combine image dependencies with application dependencies, use `byosbom` for the primary CycloneDX SBOM and `additional_sboms` for any extra CycloneDX SBOM files. These are merged by `nais/attest-sign` before attestation.
 
 ## Known issues
 

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: "Bring your own, use existing SBOM for SLSA"
     required: false
     default: "auto-generate-for-me-please.json"
+  additional_sboms:
+    description: "Newline-separated list of extra CycloneDX SBOM files to merge with the primary SBOM"
+    required: false
+    default: ""
   platforms:
     description: "List of target platforms for build"
     required: false
@@ -154,6 +158,7 @@ runs:
       with:
         image_ref: ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}@${{ steps.build_push.outputs.digest }}
         sbom: ${{ inputs.byosbom }}
+        additional_sboms: ${{ inputs.additional_sboms }}
     # For some reason, nested composite outputs aren't properly evaluated, so we need to set them again.
     - name: Set outputs
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ runs:
     - name: Generate SBOM, attest and sign image
       if: ${{ inputs.push_image == 'true' && inputs.salsa == 'true' }}
       id: attest-sign
-      uses: nais/attest-sign@2548fccb3e472f3f65d1cf0fe6e339c7675d3c55 # ratchet:nais/attest-sign@v2
+      uses: nais/attest-sign@bb00e4baa4e7acd00b6aff2502b2dfed3d4fad40 # ratchet:nais/attest-sign@v2
       with:
         image_ref: ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}@${{ steps.build_push.outputs.digest }}
         sbom: ${{ inputs.byosbom }}


### PR DESCRIPTION
This pull request adds support for merging multiple CycloneDX SBOM (Software Bill Of Materials) files during the image attestation process. Users can now specify extra SBOM files in addition to the primary one, and these will be merged automatically. The documentation and action inputs are updated to reflect this new capability.

**SBOM merging support:**

* action.yml Introduced a new `additional_sboms` input for specifying a newline-separated list of extra CycloneDX SBOM files to merge with the primary SBOM, and passed this input to the attestation step. Documented the new `additional_sboms` option in the usage example and explained how to combine image and application dependencies using both `byosbom` and `additional_sboms`. 