### PR TITLE
Feature/image tag digest output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This action contains recommended steps for building and publishing a Docker imag
 
 It will authenticate with the registry and build the image, named after the repository, and use a generated tag containing the timestamp and short commit hash.
 
+The `image` output is the canonical image reference. When a digest is available, it is returned as `<registry>/<repo>:<tag>@<digest>` so deployments and attestation can use an immutable image reference while still preserving the readable tag.
+
+Before:
+
+`europe-north1-docker.pkg.dev/nais-io/nais/images/app:2026.07.01-12.34-abcdef0`
+
+After:
+
+`europe-north1-docker.pkg.dev/nais-io/nais/images/app:2026.07.01-12.34-abcdef0@sha256:abc123...`
+
+If no digest is available, the `image` output falls back to the tagged image reference only. This can happen for example when `push_image` is `false`, or when the underlying build step does not produce a digest. Consumers that require an immutable image reference should ensure a digest is present before using the output for deployment or attestation.
+
 If you need to build multiple images from the same repository, you can use the `image_suffix` input to add a suffix to the image name.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ After:
 
 `europe-north1-docker.pkg.dev/nais-io/nais/images/app:2026.07.01-12.34-abcdef0@sha256:abc123...`
 
-If no digest is available, the `image` output falls back to the tagged image reference only. This can happen for example when `push_image` is `false`, or when the underlying build step does not produce a digest. Consumers that require an immutable image reference should ensure a digest is present before using the output for deployment or attestation.
+If no pushed-image digest is available, the `image` output falls back to the tagged image reference only. This happens when `push_image` is `false`, or when the underlying build step does not produce a digest for a pushed image. Consumers that require an immutable registry reference should ensure `push_image` is `true` and that a digest is present before using the output for deployment or attestation.
 
 If you need to build multiple images from the same repository, you can use the `image_suffix` input to add a suffix to the image name.
 

--- a/action.yml
+++ b/action.yml
@@ -171,7 +171,7 @@ runs:
         fi
 
         if [[ "$image" == *"@"* ]] && [ -n "$digest" ]; then
-          echo "::error ::Failed to construct canonical image reference. Expected image tag without digest, but image already contained '@' while a separate digest was also provided."
+          echo "::error ::Image tag must not include a digest when digest is provided separately."
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -182,7 +182,7 @@ runs:
 
         image_ref="$image"
 
-        if [ -n "$digest" ]; then
+        if [ "$PUSH_IMAGE" = 'true' ] && [ -n "$digest" ]; then
           image_ref="$image@$digest"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -199,13 +199,15 @@ runs:
     - name: Set outputs
       shell: bash
       id: set-outputs
+      env:
+        IMAGE: ${{ steps.image-ref.outputs.image }}
+        DIGEST: ${{ steps.build_push.outputs.digest }}
+        NEW_VERSION: ${{ steps.meta.outputs.version }}
+        SALSA_OUTPUT: ${{ steps.attest-sign.outputs.sbom }}
       run: |
         set -euo pipefail
 
-        image="${{ steps.image-ref.outputs.image }}"
-        digest="${{ steps.build_push.outputs.digest }}"
-
-        echo "new_version=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
-        echo "image=$image" >> "$GITHUB_OUTPUT"
-        echo "digest=$digest" >> "$GITHUB_OUTPUT"
-        echo "salsa=${{ steps.attest-sign.outputs.sbom }}" >> "$GITHUB_OUTPUT"
+        echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+        echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+        echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+        echo "salsa=$SALSA_OUTPUT" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -73,16 +73,16 @@ inputs:
 outputs:
   salsa:
     description: "SLSA attestation"
-    value: ${{ steps.set-outputs.outputs.SALSA }}
+    value: ${{ steps.set-outputs.outputs.salsa }}
   digest:
     description: "Image digest"
-    value: ${{ steps.set-outputs.outputs.DIGEST }}
+    value: ${{ steps.set-outputs.outputs.digest }}
   tag:
     description: "Release tag"
-    value: ${{ steps.set-outputs.outputs.NEW_VERSION }}
+    value: ${{ steps.set-outputs.outputs.new_version }}
   image:
-    description: "Image name"
-    value: ${{ steps.set-outputs.outputs.IMAGE }}
+    description: "Canonical image reference"
+    value: ${{ steps.set-outputs.outputs.image }}
 runs:
   using: "composite"
   steps:
@@ -151,12 +151,48 @@ runs:
       run: |
         echo "::error ::Failed during image build. Is your docker_context set to where your build files are?"
         exit 1
+    - name: Build canonical image ref
+      shell: bash
+      id: image-ref
+      env:
+        IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        IMAGE_DIGEST: ${{ steps.build_push.outputs.digest }}
+        PUSH_IMAGE: ${{ inputs.push_image }}
+        SALSA: ${{ inputs.salsa }}
+      run: |
+        set -euo pipefail
+
+        image="${IMAGE_TAGS%%$'\n'*}"
+        digest="${IMAGE_DIGEST#@}"
+
+        if [ -z "$image" ]; then
+          echo "::error ::Failed to resolve image tag from docker metadata output. Expected steps.meta.outputs.tags to contain at least one image tag."
+          exit 1
+        fi
+
+        if [[ "$image" == *"@"* ]] && [ -n "$digest" ]; then
+          echo "::error ::Failed to construct canonical image reference. Expected image tag without digest, but image already contained '@' while a separate digest was also provided."
+          exit 1
+        fi
+
+        if [ "$PUSH_IMAGE" = 'true' ] && [ "$SALSA" = 'true' ] && [ -z "$digest" ]; then
+          echo "::error ::Failed to resolve image digest from docker build output. Digest is required when push_image=true and salsa=true."
+          exit 1
+        fi
+
+        image_ref="$image"
+
+        if [ -n "$digest" ]; then
+          image_ref="$image@$digest"
+        fi
+
+        echo "image=$image_ref" >> "$GITHUB_OUTPUT"
     - name: Generate SBOM, attest and sign image
       if: ${{ inputs.push_image == 'true' && inputs.salsa == 'true' }}
       id: attest-sign
       uses: nais/attest-sign@bb00e4baa4e7acd00b6aff2502b2dfed3d4fad40 # ratchet:nais/attest-sign@v2
       with:
-        image_ref: ${{ steps.login.outputs.registry }}/${{ steps.setup.outputs.REPO_NAME }}@${{ steps.build_push.outputs.digest }}
+        image_ref: ${{ steps.image-ref.outputs.image }}
         sbom: ${{ inputs.byosbom }}
         additional_sboms: ${{ inputs.additional_sboms }}
     # For some reason, nested composite outputs aren't properly evaluated, so we need to set them again.
@@ -164,7 +200,12 @@ runs:
       shell: bash
       id: set-outputs
       run: |
-        echo "NEW_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_OUTPUT
-        echo "IMAGE=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
-        echo "DIGEST=${{ steps.build_push.outputs.digest }}" >> $GITHUB_OUTPUT
-        echo "SALSA=${{ steps.attest-sign.outputs.sbom }}" >> $GITHUB_OUTPUT
+        set -euo pipefail
+
+        image="${{ steps.image-ref.outputs.image }}"
+        digest="${{ steps.build_push.outputs.digest }}"
+
+        echo "new_version=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+        echo "image=$image" >> "$GITHUB_OUTPUT"
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "salsa=${{ steps.attest-sign.outputs.sbom }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This pull request improves the way Docker image references are handled and outputted, ensuring that consumers receive a canonical, immutable image reference when possible. The changes also update output variable naming for consistency and clarify documentation.

**Canonical image reference handling:**

* Added a new step to construct a canonical image reference (including digest when available) and output it as `image`, ensuring deployments and attestations use an immutable reference. If a digest is unavailable, it falls back to the tag-only reference.
* Updated the SBOM generation and attestation step to use the new canonical image reference output, improving reliability and consistency of downstream processes.

**Output variable improvements:**

* Standardized output variable names to lowercase (`image`, `digest`, `new_version`, `salsa`) for consistency across the workflow and outputs. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L76-R85) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R154-R211)

**Documentation updates:**

* Enhanced the `README.md` to explain the new behavior of the `image` output, including before/after examples and guidance for consumers regarding digest availability.